### PR TITLE
Don't map <C-U> and <C-D> in insert mode

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,6 @@ you would like to have scroll working as normal mode, add the lines below to
 your vimrc file.
 
 ```
-noremap <C-U> <Esc><C-U>i
-noremap <C-D> <Esc><C-D>i
+inoremap <C-U> <Esc><C-U>i
+inoremap <C-D> <Esc><C-D>i
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -29,7 +29,6 @@ this.
   argument; I use ten milliseconds). *Note*: just like slowing down the frame
   rate on a video, if you slow down the smooth scroll too much it will be jerky
   scroll.
-+ Works in normal or insert mode (i.e. leaves you in insert mode if you were
   already in insert mode)
 + Simple and lightweight
 
@@ -51,3 +50,14 @@ and then executing:
 or the equivalent. Alternatively, you can copy `plugin/SimpleSmoothScroll.vim`
 to `~/.vim/plugin`. (Note: you may have to use `~\vimfiles` instead of
 `~/.vim` if you are on Windows...)
+
+### Insert mode
+
+By default <C-D> and <C-U> have different purposes in insert mode. However if
+you would like to have scroll working as normal mode, add the lines below to
+your vimrc file.
+
+```
+noremap <C-U> <Esc><C-U>i
+noremap <C-D> <Esc><C-D>i
+```

--- a/plugin/SimpleSmoothScroll.vim
+++ b/plugin/SimpleSmoothScroll.vim
@@ -35,8 +35,6 @@ endfunction
 
 nnoremap <C-U> :call <SID>ScrollUp()<Enter>
 nnoremap <C-D> :call <SID>ScrollDown()<Enter>
-inoremap <C-U> <Esc>:call <SID>ScrollUp()<Enter>i
-inoremap <C-D> <Esc>:call <SID>ScrollDown()<Enter>i
 map <ScrollWheelUp> <C-Y>
 map <ScrollWheelDown> <C-E>
 


### PR DESCRIPTION
This isn't the default behavior of Vim. <C-D>  is used for adjusting indentation during insert mode.